### PR TITLE
Add support for rate limiting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@tonymacdonald/node-red-rapt-pull",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tonymacdonald/node-red-rapt-pull",
-      "version": "1.0.0",
-      "license": "ISC",
+      "version": "0.9.2",
+      "license": "MIT",
       "dependencies": {
         "request": "^2.88.2"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tonymacdonald/node-red-rapt-pull",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Simple node to pull data from RAPT cloud for integration into Node-RED flows",
   "dependencies": {
     "request": "^2.88.2"


### PR DESCRIPTION
RAPT api is limited to 5 requests per minute. Add support for rate limiting so that get hydrometers request can be chained to other requests even when there are a many hydrometers registered.